### PR TITLE
Remove non-ascii caracters from the scripts

### DIFF
--- a/tools/scripts/build.py
+++ b/tools/scripts/build.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016, Gepard Graphics
 # Copyright (C) 2016, Dániel Bátyai <dbatyai@inf.u-szeged.hu>

--- a/tools/scripts/cppcheck.py
+++ b/tools/scripts/cppcheck.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016, Gepard Graphics
 # Copyright (C) 2016, Dániel Bátyai <dbatyai@inf.u-szeged.hu>

--- a/tools/scripts/run-tests.py
+++ b/tools/scripts/run-tests.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016, Gepard Graphics
 # Copyright (C) 2016, Dániel Bátyai <dbatyai@inf.u-szeged.hu>

--- a/tools/scripts/unittest.py
+++ b/tools/scripts/unittest.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016, Gepard Graphics
 # Copyright (C) 2016, Dániel Bátyai <dbatyai@inf.u-szeged.hu>


### PR DESCRIPTION
Some of the licences contained non-ascii character (i.e. 'á') which broke the python scripts.