### PR TITLE
Fix building unit-tests for different backends when running tests

### DIFF
--- a/tools/scripts/build.py
+++ b/tools/scripts/build.py
@@ -36,13 +36,21 @@ from os import makedirs
 
 def create_options(arguments):
     """ Create a CMake option list from parsed arguments. """
+
+    if not hasattr(arguments, 'build_type') or not hasattr(arguments, 'backend'):
+        raise AttributeError("Argument object isn't configured correctly.")
+
     opts = [
             '-DCMAKE_BUILD_TYPE=' + arguments.build_type.capitalize(),
             '-DBACKEND=' + arguments.backend.upper(),
-            '-DLOG_LEVEL=' + str(arguments.log_level)
     ]
 
-    if arguments.no_colored_logs:
+    log_level = getattr(arguments, 'log_level', 0)
+    if log_level:
+        opts.append('-DLOG_LEVEL=' + str(log_level))
+
+    no_colored_logs = getattr(arguments, 'no_colored_logs', False)
+    if no_colored_logs:
         opts.append('-DDISABLE_LOG_COLORS=ON')
 
     return opts

--- a/tools/scripts/run-tests.py
+++ b/tools/scripts/run-tests.py
@@ -59,6 +59,7 @@ def main():
     if not arguments.all:
         result.append((run_unittest(arguments, throw=False), "Unit-tests"))
     else:
+        arguments.build_type='debug'
         arguments.backend="gles2"
         result.append((run_unittest(arguments, throw=False), "Unit-tests GLES2"))
         arguments.backend="vulkan"

--- a/tools/scripts/unittest.py
+++ b/tools/scripts/unittest.py
@@ -39,8 +39,7 @@ def run_unittest(args, throw=True):
 
     print('')
     print("Building unit-tests...")
-    # We use the argument parser from the main build script here to initialize all required members of the argument structure.
-    build.configure(build.get_args(skip_unknown=True))
+    build.configure(args)
     build.build_unit(args)
 
     print('')


### PR DESCRIPTION
This PR fixes the issue of building unit-tests with the incorrect back-ends when running run-test.py.

Signed-off-by: Dániel Bátyai <dbatyai@inf.u-szeged.hu>