### PR TITLE
Use trusty environment for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: cpp
 os: linux
+sudo: required
+dist: trusty
 
 before_script:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo add-apt-repository -y ppa:andykimpe/cmake
   - sudo apt-get -qq update
-  - sudo apt-get -qq install g++-4.8 gcc-4.8
   - sudo apt-get -qq install cmake
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 
 fast_finish: true
 


### PR DESCRIPTION
Using it improves travis build times significantly, since we no longer have to set up GCC 4.8.