### PR TITLE
Return with an error code when one of the builds fail

### DIFF
--- a/tools/scripts/travis.sh
+++ b/tools/scripts/travis.sh
@@ -30,10 +30,12 @@ if [ "$CMD" == "build" ]; then
     fi
 
     echo "Running Release build with examples."
-    python tools/scripts/build.py -e $backend $ARGS
+    if ! python tools/scripts/build.py -e $backend $ARGS; then ret=1; fi
 
-    echo "Running Debug build."
-    python tools/scripts/build.py -d $backend $ARGS
+    echo "Running Debug build.";
+    if ! python tools/scripts/build.py -d $backend $ARGS; then ret=1; fi
+
+    exit $ret
 else
     python tools/scripts/$CMD.py
 fi


### PR DESCRIPTION
Currently only the return value of the last build is checked, which means Travis would pass if only the first build failed.