### PR TITLE
API Changing. Remove controversial functions.

### DIFF
--- a/apps/examples/fill-rect/fill-rect.cpp
+++ b/apps/examples/fill-rect/fill-rect.cpp
@@ -33,22 +33,22 @@
 
 void pathShape(gepard::Gepard& gepard)
 {
-    gepard.setFillColor(0.5f, 0.4f, 0.1f, 0.2f);
+    gepard.setFillColor(128, 102, 26, 0.05f);
     gepard.fillRect(50, 50, 500, 500);
 
-    gepard.setFillColor(0.0f, 0.8f, 0.3f, 0.8f);
+    gepard.setFillColor(0, 204, 77, 0.8f);
     gepard.fillRect(100, 100, 80, 400);
 
-    gepard.setFillColor(0.0f, 0.0f, 1.0f, 0.8f);
+    gepard.setFillColor(0, 0, 26, 0.8f);
     gepard.fillRect(100, 420, 280, 80);
 
-    gepard.setFillColor(0.3f, 0.0f, 0.7f);
+    gepard.setFillColor(77, 0, 179);
     gepard.fillRect(180, 100, 200, 80);
 
-    gepard.setFillColor(0.3f, 0.7f, 0.2f);
+    gepard.setFillColor(77, 179, 51);
     gepard.fillRect(380, 80, 80, 130);
 
-    gepard.setFillColor("#af5f4f");
+    gepard.fillStyle = "#af5f4f";
     gepard.fillRect(380, 380, 80, 130);
 
     gepard.setFillColor(220, 180, 40);

--- a/src/gepard.cpp
+++ b/src/gepard.cpp
@@ -60,7 +60,7 @@ Gepard::Attribute& Gepard::Attribute::operator=(const std::string& str)
     return *this;
 }
 
-Gepard::Attribute&Gepard::Attribute::operator=(const char* chs)
+Gepard::Attribute& Gepard::Attribute::operator=(const char* chs)
 {
     this->operator=(std::string(chs)); return *this;
 }
@@ -635,22 +635,18 @@ void Gepard::putImageData(Image /*imagedata*/, double dx, double dy, double dirt
     /*! \todo unimplemented function */
 }
 
-void Gepard::setFillColor(const std::string& color)
+void Gepard::setFillColor(const int red, const int green, const int blue, const float alpha)
 {
     GD_ASSERT(_engine);
-    _engine->setFillColor(Color(color));
-}
-
-void Gepard::setFillColor(const int red, const int green, const int blue, const int alpha)
-{
     const float ratio = 1.0f / 255.0f;
-    setFillColor(ratio * float(red), ratio * float(green), ratio * float(blue), ratio * float(alpha));
+    _engine->setFillColor(Color(ratio * float(red), ratio * float(green), ratio * float(blue), float(alpha)));
 }
 
-void Gepard::setFillColor(const float red, const float green, const float blue, const float alpha)
+void Gepard::setStrokeColor(const int red, const int green, const int blue, const float alpha)
 {
     GD_ASSERT(_engine);
-    _engine->setFillColor(red, green, blue, alpha);
+    const float ratio = 1.0f / 255.0f;
+    _engine->setStrokeColor(Color(ratio * float(red), ratio * float(green), ratio * float(blue), float(alpha)));
 }
 
 // Virtual destructor definition for the abstract Surface class.

--- a/src/gepard.h
+++ b/src/gepard.h
@@ -438,29 +438,17 @@ public:
      * \param red  the red channel in range [0, 255]
      * \param green  the green channel in range [0, 255]
      * \param blue  the blue channel in range [0, 255]
-     * \param alpha  the alpha channel in range [0, 255]
-     */
-    void setFillColor(const int red, const int green, const int blue, const int alpha = 255);
-    /*!
-     * \brief Set fill color with red, green, blue and alpha components
-     * \param red  the red channel in range [0.0, 1.0]
-     * \param green  the green channel in range [0.0, 1.0]
-     * \param blue  the blue channel in range [0.0, 1.0]
      * \param alpha  the alpha channel in range [0.0, 1.0]
      */
-    void setFillColor(const float red, const float green, const float blue, const float alpha = 1.0f);
+    void setFillColor(const int red, const int green, const int blue, const float alpha = 1.0f);
     /*!
-     * \brief Set fill color with red, green and blue components using a string
-     * \param color  an '#RRGGBB' color string.
-     *
-     * Sets the red, green and blue channels with a hex string, where:
-     * * RR is the red channel in range '00'-'FF',
-     * * GG is the green channel in range '00'-'FF',
-     * * BB is the blue channel in range '00'-'FF'.
-     *
-     * \note A shorter form can also be used: '#RGB'.
+     * \brief Set stroke color with red, green, blue and alpha components
+     * \param red  the red channel in range [0, 255]
+     * \param green  the green channel in range [0, 255]
+     * \param blue  the blue channel in range [0, 255]
+     * \param alpha  the alpha channel in range [0.0, 1.0]
      */
-    void setFillColor(const std::string& color = "#000000");
+    void setStrokeColor(const int red, const int green, const int blue, const float alpha = 1.0f);
 
     /// \} A. NonCanvasAPI Functions
 


### PR DESCRIPTION
Removed two controversial color setter functions.
The remaining one is the Canvas 2D recommendation based variant:
  setFillColor(uchar, uchar, uchar, float),
where uchar range is in [0-255] and float range is in [0.0-1.0].