### PR TITLE
Rework thirdparty dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ __pycache__
 
 # 'temp' directory for local usage
 temp
+
+# thirdparty directories
+thirdparty/src
+thirdparty/bin
+thirdparty/lib
+thirdparty/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ file(MAKE_DIRECTORY ${INCLUDE_OUTPUT_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BINARY_OUTPUT_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR})
 
-add_subdirectory(thirdparty)
 add_subdirectory(src)
 add_subdirectory(apps EXCLUDE_FROM_ALL)
 add_subdirectory(tests/unit EXCLUDE_FROM_ALL)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,14 +13,14 @@ set(COMMON_INCLUDE_DIRS
 )
 
 add_executable(unittest ${SOURCES})
-add_dependencies(unittest gtest)
 
 # Pthread required by gtest
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads)
 
-target_include_directories(unittest PUBLIC ${PROJECT_BINARY_DIR}/thirdparty/include)
+target_include_directories(unittest PUBLIC ${PROJECT_SOURCE_DIR}/thirdparty/include)
 target_include_directories(unittest PUBLIC ${COMMON_INCLUDE_DIRS})
 
-target_link_libraries(unittest ${PROJECT_BINARY_DIR}/thirdparty/lib/libgtest.a ${CMAKE_THREAD_LIBS_INIT})
+# TODO(dbatyai): use find_package for gtest
+target_link_libraries(unittest ${PROJECT_SOURCE_DIR}/thirdparty/lib/libgtest.a ${CMAKE_THREAD_LIBS_INIT})

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,10 +1,56 @@
+cmake_minimum_required(VERSION 2.8.10)
+project(gepard-thirdparty)
+set(PROJECT_VERSION 0.0.1)
+
+# The outer build system will look in these folders for required files
+set(BINARY_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/bin)
+set(LIB_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/lib)
+set(INCLUDE_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/include)
+
+# Dependencies are handled by the custom targets listed below this comment
+# block. The build script will call these respective targets when building
+# dependencies for a specific backend.
+# The process of adding a new dependency should consist of creating a build
+# step that is responsible for building and installing the library, and then
+# adding this step as a dependency to the the custom target of the backend
+# that requires this dependency.
+#
+# When creating the build step, the following general rules apply:
+# - Source code should be fetched into a subdirectory of the 'src' directory.
+# - Created output files should be installed into their respective directories
+#   defined above this comment block.
+# - A subdirectory in PROJECT_BINARY_DIR can be used as a build directory.
+
+add_custom_target(common ALL
+                  DEPENDS gtest)
+
+add_custom_target(gles2 ALL
+                  DEPENDS common)
+
+add_custom_target(vulkan ALL
+                  DEPENDS common)
+
+add_custom_target(software ALL
+                  DEPENDS common)
+
 include(ExternalProject)
 
 ExternalProject_Add(gtest
-                    PREFIX ${PROJECT_SOURCE_DIR}/thirdparty/googletest
+                    PREFIX ${PROJECT_SOURCE_DIR}/src/googletest
                     GIT_REPOSITORY https://github.com/google/googletest.git
-                    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/thirdparty -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_INCLUDEDIR=include -DBUILD_GMOCK=OFF -DBUILD_GTEST=ON
+                    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_INCLUDEDIR=include -DBUILD_GMOCK=OFF
                     GIT_TAG release-1.8.1
-                    BINARY_DIR ${PROJECT_BINARY_DIR}/thirdparty/googletest
+                    BINARY_DIR ${PROJECT_BINARY_DIR}/googletest
                     BUILD_COMMAND make gtest
                     INSTALL_COMMAND make install > /dev/null)
+
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/stamps)
+add_custom_command(TARGET gles2
+                  POST_BUILD
+                  COMMAND touch ${PROJECT_BINARY_DIR}/stamps/gles2.stamp)
+add_custom_command(TARGET vulkan
+                  POST_BUILD
+                  COMMAND touch ${PROJECT_BINARY_DIR}/stamps/vulkan.stamp)
+add_custom_command(TARGET software
+                  POST_BUILD
+                  COMMAND touch ${PROJECT_BINARY_DIR}/stamps/software.stamp)

--- a/tools/build.py
+++ b/tools/build.py
@@ -26,6 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import dependencies
 import subprocess
 import sys
 import util
@@ -62,6 +63,7 @@ def add_args(parser):
     parser.add_argument('--build-dir', '-b', action='store', dest='build_dir', help='Specify build directory.')
     parser.add_argument('--install-prefix', action='store', dest='install_prefix', help='Specify install prefix.')
     parser.add_argument('--debug', '-d', action='store_const', const='debug', default='release', dest='build_type', help='Build debug.')
+    parser.add_argument('--rebuild-deps', action='store_true', default=False, help='Rebuild thirdparty dependencies.')
     parser.add_argument('--backend', action='store', choices=['gles2', 'software', 'vulkan'], default='gles2', help='Specify which graphics back-end to use.')
     parser.add_argument('--log-level', '-l', action='store', type=int, choices=range(0,5), default=0, help='Set logging level.')
     parser.add_argument('--no-colored-logs', action='store_true', default=False, help='Disable colored log messages.')
@@ -76,22 +78,20 @@ def get_args(skip_unknown=False):
     return parser.parse_args()
 
 
-def configure(arguments):
+def configure(source_path, build_path, arguments=None):
     """ Configures the build based on the supplied arguments. """
-    build_path = util.get_build_path(arguments)
-
     try:
         makedirs(build_path)
     except OSError:
         pass
 
-    util.call(['cmake', '-B' + build_path, '-H' + util.get_base_path()] + create_options(arguments))
+    util.call(['cmake', '-B' + build_path, '-H' + source_path] + create_options(arguments))
 
 
-def build_targets(arguments):
-    """ Runs the build. """
-    build_command = ['make', '-s', '-C', util.get_build_path(arguments)]
-    build_command.extend(arguments.targets)
+def build_targets(build_path, targets):
+    """ Builds the specified targets. """
+    build_command = ['make', '-s', '-C', build_path]
+    build_command.extend(targets)
 
     util.call(build_command)
 
@@ -108,8 +108,10 @@ def main():
     arguments = get_args()
 
     try:
-        configure(arguments)
-        build_targets(arguments)
+        dependencies.build_dependencies([arguments.backend], arguments.rebuild_deps)
+        build_path = util.get_build_path(arguments)
+        configure(util.get_base_path(), build_path, arguments)
+        build_targets(build_path, arguments.targets)
     except util.CommandError as e:
         print("Build failed: %s" % e)
         sys.exit(e.code)

--- a/tools/dependencies.py
+++ b/tools/dependencies.py
@@ -1,8 +1,8 @@
 #! /usr/bin/python -B
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2016, Gepard Graphics
-# Copyright (C) 2016, Dániel Bátyai <dbatyai@inf.u-szeged.hu>
+# Copyright (C) 2018, Gepard Graphics
+# Copyright (C) 2018, Dániel Bátyai <dbatyai@inf.u-szeged.hu>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,39 +26,53 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-import dependencies
-import build
-import sys
 import util
-from os import path
-from os import getcwd
+import build
+import os.path
 
 
-def run_unittest(throw=True):
-    """ Runs unit-tests. """
-    args = lambda: None
-    args.build_dir = "build/unittest"
-    args.build_type = "debug"
-    args.backend = "software"
-    args.targets = ["unittest"]
-    build_path = util.get_build_path(args)
+def check_stamp(path):
+    # TODO(dbatyai): check if CMakeLists has been modified
+    return os.path.isfile(path)
 
-    print('')
-    print("Building unit-tests...")
-    dependencies.build_dependencies([args.backend])
-    build.configure(util.get_base_path(), build_path, args)
-    build.build_targets(build_path, args.targets)
 
-    print('')
-    print("Running unit-tests...")
-    return util.call([path.join(build_path, 'bin', 'unittest')], throw)
+def build_dependencies(backends, force=False):
+    source_path = os.path.join(util.get_base_path(), "thirdparty")
+    build_path = os.path.join(source_path, "build")
+
+    print('Building dependencies.')
+
+    if 'all' in backends:
+        backends = ['gles2', 'vulkan', 'software']
+
+    if force:
+        needs_build = backends
+    else:
+        needs_build = []
+        for backend in backends:
+            stamp_path = os.path.join(build_path, "stamps", "%s.stamp" % backend)
+            if not check_stamp(stamp_path):
+                needs_build.append(backend)
+
+    if not needs_build:
+        print('Nothing to do.')
+        return
+
+    build.configure(source_path, build_path)
+    build.build_targets(build_path, needs_build)
+    print('Done.')
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('backends', action='store', nargs='*', choices=['gles2', 'vulkan', 'software', 'all'], default=['all'] , help='Which backends to build dependencies for.')
+    parser.add_argument('--force', '-f', action='store_true', default=False, help='Force re-build.')
+    arguments = parser.parse_args()
+
     try:
-        run_unittest()
+        build_dependencies(arguments.backends, arguments.force)
     except util.CommandError as e:
-        print(e)
+        print("Build failed: %s" % e)
         sys.exit(e.code)
 
 


### PR DESCRIPTION
This patch separates third party libraries from the main build system.
The thirdparty directory recieved it's own CMakeLists.txt, which can be
used to build required dependencies for each backend. Dependencies are
stamped on a per-backend basis, which means they will only be built
once, and will not be rebuilt later, unless explicitly specified.