### PR TITLE
Add missing license to the VulkanShaders.cmake

### DIFF
--- a/cmake/VulkanShaders.cmake
+++ b/cmake/VulkanShaders.cmake
@@ -1,3 +1,27 @@
+# Copyright (C) 2018, Gepard Graphics
+# Copyright (C) 2018, Kristof Kosztyo <kkristof@inf.u-szeged.hu>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 set(VK_SHADER_DIRECTORY ${PROJECT_SOURCE_DIR}/src/engines/vulkan/shaders)
 set(SPIRV_DIRECTORY ${PROJECT_BINARY_DIR}/spirv)
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/spirv)


### PR DESCRIPTION
In the meantime the licences have been added to the cmake files, this new file missed this update.