### PR TITLE
Enable WSI extension in all vulkan instance

### DIFF
--- a/src/engines/vulkan/gepard-vulkan.cpp
+++ b/src/engines/vulkan/gepard-vulkan.cpp
@@ -969,9 +969,8 @@ void GepardVulkan::chooseDefaultDevice()
     enabledInstanceLayers.push_back("VK_LAYER_LUNARG_standard_validation");
 #endif
 
-    if (_context.surface->getDisplay()) {
-        enabledInstanceExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-    }
+    // TODO: enable this only when it is needed
+    enabledInstanceExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
     const char* const* enabledLayerNames = enabledInstanceLayers.empty() ? nullptr : enabledInstanceLayers.data();
     const char* const* enabledExtensionNames = enabledInstanceExtensions.empty() ? nullptr : enabledInstanceExtensions.data();


### PR DESCRIPTION
The extension functions loading is not seperated from
the core functions which leads error on some loader
implementations.
Fix issue #138.

Signed-off-by: Kristof Kosztyo <kkristof@inf.u-szeged.hu>