### PR TITLE
Add virtual specifiers for the backends

### DIFF
--- a/src/engines/gles2/gepard-gles2.h
+++ b/src/engines/gles2/gepard-gles2.h
@@ -51,7 +51,7 @@ public:
     static const int kMaximumNumberOfUshortQuads;
 
     explicit GepardGLES2(GepardContext&);
-    ~GepardGLES2();
+    virtual ~GepardGLES2();
 
     virtual void fillRect(const Float x, const Float y, const Float w, const Float h) override;
     virtual void fillPath(PathData*, const GepardState&) override;

--- a/src/engines/software/gepard-software.h
+++ b/src/engines/software/gepard-software.h
@@ -45,7 +45,7 @@ namespace software {
 class GepardSoftware : public GepardEngineBackend {
 public:
     explicit GepardSoftware(GepardContext&);
-    ~GepardSoftware();
+    virtual ~GepardSoftware();
 
     virtual void fillRect(const Float x, const Float y, const Float w, const Float h) override;
     virtual void fillPath(PathData*, const GepardState&) override;

--- a/src/engines/vulkan/gepard-vulkan.h
+++ b/src/engines/vulkan/gepard-vulkan.h
@@ -44,7 +44,7 @@ namespace vulkan {
 class GepardVulkan  : public GepardEngineBackend {
 public:
     explicit GepardVulkan(GepardContext&);
-    ~GepardVulkan() override;
+    virtual ~GepardVulkan() override;
 
     virtual void fillRect(const Float x, const Float y, const Float w, const Float h) override;
     virtual void drawImage(const Image& imagedata, const Float sx, const Float sy, const Float sw, const Float sh, const Float dx, const Float dy, const Float dw, const Float dh) override;


### PR DESCRIPTION
The GepardEngineBackend has a virtual destructor, thus all child class
should also have a virtual destructor. Without it there is a possibility
of memory leak(s) when the given backend is deleted/freed.

Signed-off-by: Peter Gal <galpeter@inf.u-szeged.hu>