### PR TITLE
Allow builds if one of the backends is disabled

### DIFF
--- a/src/gepard-engine.cpp
+++ b/src/gepard-engine.cpp
@@ -34,6 +34,16 @@
 #include <cstring>
 #include <string>
 
+#if defined(GD_BACKEND_GLES2)
+#include "gepard-gles2.h"
+#endif
+#if defined(GD_BACKEND_VULKAN)
+#include "gepard-vulkan.h"
+#endif
+#if defined(GD_BACKEND_SOFTWARE)
+#include "gepard-software.h"
+#endif
+
 namespace gepard {
 
 static const std::string nameOfBackend(const BackendType backendType)

--- a/src/gepard-engine.h
+++ b/src/gepard-engine.h
@@ -28,14 +28,12 @@
 
 #include "gepard-color.h"
 #include "gepard-context.h"
+#include "gepard-engine-backend.h"
 #include "gepard-float.h"
 #include "gepard-float-point.h"
-#include "gepard-gles2.h"
 #include "gepard-image.h"
 #include "gepard-logging.h"
-#include "gepard-software.h"
 #include "gepard-state.h"
-#include "gepard-vulkan.h"
 #include <string>
 
 namespace gepard {


### PR DESCRIPTION
After the backend rework the build required that all backends are enabled
in every case. If one of the headers was disabled a missing header error
would be reported.

By moving the inclusion of the headers to the gepard-engine.ccp file and
guarding them correctly the build problem can be resolved.

Signed-off-by: Peter Gal <galpeter@inf.u-szeged.hu>