### PR TITLE
Use libpng-dev instead of libpng16-dev as dependency

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -46,7 +46,7 @@ do
   shift
 done
 
-common_list="cmake libx11-dev libpng16-dev"
+common_list="cmake libx11-dev libpng-dev"
 gles2_list="libegl1-mesa-dev libgles2-mesa-dev"
 vulkan_list=""
 


### PR DESCRIPTION
The package libpng16-dev in the recent versions of Ubuntu is no longer available.

Signed-off-by: Zsolt Borbély <borbezs@inf.u-szeged.hu>